### PR TITLE
Updated aspect ratio docs to allow for nested use

### DIFF
--- a/styling/aspect-ratio.md
+++ b/styling/aspect-ratio.md
@@ -34,8 +34,9 @@ function AspectView(props) {
     <View
       {...props}
       style={style}
-      onLayout={({ nativeEvent: { layout } }) => setLayout(layout)}
-    />
+      onLayout={({ nativeEvent: { layout } }) => setLayout(layout)}>
+      {layout ? props.children : null}
+    </View>
   );
 }
 

--- a/styling/aspectRatio.md
+++ b/styling/aspectRatio.md
@@ -32,8 +32,9 @@ function AspectView(props) {
     <View
       {...props}
       style={style}
-      onLayout={({ nativeEvent: { layout } }) => setLayout(layout)}
-    />
+      onLayout={({ nativeEvent: { layout } }) => setLayout(layout)}>
+      {layout ? props.children : null}
+    </View>
   );
 }
 


### PR DESCRIPTION
Currently if the AspectView component described is nested within another the parent will shrink to the dimensions of the child. I've added `{layout ? props.children : null}` to ensure the parent layout is set properly before calculating the layout of its children.

Before:
<img width="281" alt="Screenshot 2020-01-06 at 21 53 55" src="https://user-images.githubusercontent.com/31568400/71851772-2b3cf480-30cf-11ea-8488-e9eddbf161c6.png">

After: 
<img width="293" alt="Screenshot 2020-01-06 at 21 53 05" src="https://user-images.githubusercontent.com/31568400/71851767-28da9a80-30cf-11ea-9778-e3495af0114a.png">

Thanks for the great work on the web side of things!